### PR TITLE
Add `bugs` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy"
   },
+  "bugs": {
+    "url": "https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy/issues"
+  },
   "keywords": [
     "netlify",
     "netlify-plugin",


### PR DESCRIPTION
This adds a `bugs` field in `package.json`. This field is used when an error happens in the plugin.