### PR TITLE
Remove top-level function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,13 @@
 const fs = require('fs');
 
-
-function netlifyPlugin(conf) {
-
-  // Where does the plugin config tell us to put data?
-  const DATA_DIR = conf.data_dir;
-  let PLUGIN_CACHE_ROOT;
-  let CACHE_FOLDERS = [];
-
-  return {
+module.exports = {
 
     // Hook into lifecycle
     onPreBuild: (data) => {
+      // Where does the plugin inputs tell us to put data?
+      const DATA_DIR = data.inputs.data_dir;
+      let PLUGIN_CACHE_ROOT;
+      let CACHE_FOLDERS = [];
 
       const prodCache = '/opt/build/cache';
       if (fs.existsSync(prodCache)) {
@@ -23,7 +19,7 @@ function netlifyPlugin(conf) {
       }
 
       // collect an array of every folder specified in yaml
-      conf.cache_sources.forEach(folder => {
+      data.inputs.cache_sources.forEach(folder => {
         CACHE_FOLDERS.push(`${PLUGIN_CACHE_ROOT}/${folder}`)
       });
 
@@ -59,8 +55,4 @@ function netlifyPlugin(conf) {
 
       });
     }
-
-  };
 };
-
-module.exports = netlifyPlugin;


### PR DESCRIPTION
This removes the top-level function of this plugin, since this is optional and is not required in this specific plugin.